### PR TITLE
2025/06/19 attachments-02 - by rudsonalves

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,67 @@ A new Flutter project.
 
 # ChangeLog
 
+## 2025/06/19 attachments-02 - by rudsonalves
+
+### Add file picker support and extend attachment/session route parameters
+
+This commit enhances attachment handling by introducing a `name` field to the `AttachmentModel`, integrates the `file_picker` package for file selection, and refactors routing to pass additional identifiers (`userId`, `episodeId`, `sessionId`). Validation and UI elements have been updated accordingly to improve the form interaction and maintain consistency across views.
+
+### Modified Files
+
+* **lib/domain/models/attachment\_model.dart**
+
+  * Introduced a new `name` property and required it in the constructor.
+  * Made `createdAt` optional with a default of `DateTime.now()`.
+  * Updated `copyWith`, `toMap`, and `fromMap` methods to include `name`.
+
+* **lib/routing/router.dart**
+
+  * Refactored `formEpisode`, `formSession`, and `formAttachment` routes to read `state.extra` as a `Map<String, dynamic>`.
+  * Extracted and passed `userId`, `episodeId`, and `sessionId` to their respective views.
+  * Simplified builder signatures and removed old `state.extra as Model` casts.
+
+* **lib/routing/routes\_base/attachment\_routes.dart**
+
+  * Mirrored the router changes: now unpacks `sessionId` and optional `attachment` from `state.extra`.
+
+* **lib/ui/view/attachment/attachment\_view\.dart**
+
+  * Corrected import paths to use root-relative (`/routing` and `/ui/core`) instead of package prefixes.
+
+* **lib/ui/view/attachment/form\_attachment/form\_attachment\_view\.dart**
+
+  * Added `file_picker` import and declared a required `sessionId` parameter on `FormAttachmentView`.
+  * Replaced plain button with `BigButton` and wrapped the file path field in an `InkWell` to trigger `_selectFile()`.
+  * Inserted an `EnumFormField` for selecting `AttachmentType`.
+  * Implemented `_initializeForm()`, `_isSaved()`, and `_saveForm()` methods to handle edit/save logic and error reporting.
+  * Integrated `FilePicker` to allow users to choose files with specific extensions.
+
+* **lib/ui/view/episode/form\_episode/form\_episode\_view\.dart**
+
+  * Added a required `userId` field to the `FormEpisodeView` constructor.
+
+* **lib/ui/view/home/form\_user/form\_user\_view\.dart**
+
+  * Made the `SnackBar` constant and removed the inline error interpolation for consistency.
+
+* **lib/ui/view/session/form\_session/form\_session\_view\.dart**
+
+  * Changed `session` to be nullable and introduced a required `episodeId` parameter.
+
+* **lib/utils/validates/generic\_validations.dart**
+
+  * Added a new `attachmentType` validator to ensure a file type is selected.
+
+* **pubspec.yaml**
+
+  * Added `file_picker: ^10.2.0` to dependencies for file selection functionality.
+
+### Conclusion
+
+### All changes complete – attachment forms now support naming and file selection, and routing carries the correct identifiers.
+
+
 ## 2025/06/19 attachments-01 - by rudsonalves
 
 ### Implement Attachment feature and refine routing, forms, and validations

--- a/lib/domain/models/attachment_model.dart
+++ b/lib/domain/models/attachment_model.dart
@@ -3,6 +3,7 @@ import '/domain/enums/enums_declarations.dart';
 class AttachmentModel {
   final String? id;
   final String sessionId;
+  final String name;
   final String path;
   final AttachmentType type;
   final DateTime createdAt;
@@ -10,14 +11,16 @@ class AttachmentModel {
   AttachmentModel({
     this.id,
     required this.sessionId,
+    required this.name,
     required this.path,
     required this.type,
-    required this.createdAt,
-  });
+    DateTime? createdAt,
+  }) : createdAt = createdAt ?? DateTime.now();
 
   AttachmentModel copyWith({
     String? id,
     String? sessionId,
+    String? name,
     String? path,
     AttachmentType? type,
     DateTime? createdAt,
@@ -25,6 +28,7 @@ class AttachmentModel {
     return AttachmentModel(
       id: id ?? this.id,
       sessionId: sessionId ?? this.sessionId,
+      name: name ?? this.name,
       path: path ?? this.path,
       type: type ?? this.type,
       createdAt: createdAt ?? this.createdAt,
@@ -37,6 +41,7 @@ class AttachmentModel {
     if (id != null) map['id'] = id;
 
     map['session_id'] = sessionId;
+    map['name'] = name;
     map['path'] = path;
     map['type'] = type.name;
     map['created_at'] = createdAt.toIso8601String();
@@ -48,6 +53,7 @@ class AttachmentModel {
     return AttachmentModel(
       id: map['id'] as String?,
       sessionId: map['session_id'] as String,
+      name: map['name'] as String,
       path: map['path'] as String,
       type: AttachmentType.byName(map['type'] as String),
       createdAt: DateTime.parse(map['created_at'] as String),

--- a/lib/routing/router.dart
+++ b/lib/routing/router.dart
@@ -88,14 +88,21 @@ GoRouter router() => GoRouter(
         GoRoute(
           path: Routes.formEpisode.path,
           name: Routes.formEpisode.name,
-          pageBuilder: (context, state) => MaterialPage(
-            child: FormEpisodeView(
-              episode: state.extra as EpisodeModel?,
-              viewModel: FormEpisodeViewModel(
-                RepositoryScope.of<IEpisodeRepository>(context),
+          pageBuilder: (context, state) {
+            final map = state.extra as Map<String, dynamic>;
+            final userId = map['user_id'] as String;
+            final episode = map['episode'] as EpisodeModel?;
+
+            return MaterialPage(
+              child: FormEpisodeView(
+                episode: episode,
+                userId: userId,
+                viewModel: FormEpisodeViewModel(
+                  RepositoryScope.of<IEpisodeRepository>(context),
+                ),
               ),
-            ),
-          ),
+            );
+          },
         ),
         // Sessions pages
         ShellRoute(
@@ -116,26 +123,29 @@ GoRouter router() => GoRouter(
             GoRoute(
               path: Routes.session.path,
               name: Routes.session.name,
-              builder: (context, state) {
-                final episode = state.extra as EpisodeModel;
-
-                return SessionView(
-                  episode: episode,
-                  viewModel: SessionViewModel(
-                    RepositoryScope.of<ISessionRepository>(context),
-                  ),
-                );
-              },
+              builder: (context, state) => SessionView(
+                episode: state.extra as EpisodeModel,
+                viewModel: SessionViewModel(
+                  RepositoryScope.of<ISessionRepository>(context),
+                ),
+              ),
             ),
             GoRoute(
               path: Routes.formSession.path,
               name: Routes.formSession.name,
-              builder: (context, state) => FormSessionView(
-                session: state.extra as SessionModel,
-                viewModel: FormSessionViewModel(
-                  RepositoryScope.of<ISessionRepository>(context),
-                ),
-              ),
+              builder: (context, state) {
+                final map = state.extra as Map<String, dynamic>;
+                final episodeId = map['episode_id'] as String;
+                final session = map['session'] as SessionModel?;
+
+                return FormSessionView(
+                  episodeId: episodeId,
+                  session: session,
+                  viewModel: FormSessionViewModel(
+                    RepositoryScope.of<ISessionRepository>(context),
+                  ),
+                );
+              },
             ),
             // Attachments pages
             ShellRoute(
@@ -166,12 +176,19 @@ GoRouter router() => GoRouter(
                 GoRoute(
                   path: Routes.formAttachment.path,
                   name: Routes.formAttachment.name,
-                  builder: (context, state) => FormAttachmentView(
-                    attachment: state.extra as AttachmentModel,
-                    viewModel: FormAttachmentViewModel(
-                      RepositoryScope.of<IAttachmentRepository>(context),
-                    ),
-                  ),
+                  builder: (context, state) {
+                    final map = state.extra as Map<String, dynamic>;
+                    final attachment = map['attachment'] as AttachmentModel?;
+                    final sessionId = map['session_id'] as String;
+
+                    return FormAttachmentView(
+                      sessionId: sessionId,
+                      attachment: attachment,
+                      viewModel: FormAttachmentViewModel(
+                        RepositoryScope.of<IAttachmentRepository>(context),
+                      ),
+                    );
+                  },
                 ),
               ],
             ),

--- a/lib/routing/routes_base/attachment_routes.dart
+++ b/lib/routing/routes_base/attachment_routes.dart
@@ -24,11 +24,18 @@ final attachmentRoutes = <RouteBase>[
   GoRoute(
     path: Routes.formAttachment.path,
     name: Routes.formAttachment.name,
-    builder: (context, state) => FormAttachmentView(
-      attachment: state.extra as AttachmentModel,
-      viewModel: FormAttachmentViewModel(
-        RepositoryScope.of<IAttachmentRepository>(context),
-      ),
-    ),
+    builder: (context, state) {
+      final map = state.extra as Map<String, dynamic>;
+      final sessionId = map['session_id'] as String;
+      final attachment = map['attachment'] as AttachmentModel?;
+
+      return FormAttachmentView(
+        attachment: attachment,
+        sessionId: sessionId,
+        viewModel: FormAttachmentViewModel(
+          RepositoryScope.of<IAttachmentRepository>(context),
+        ),
+      );
+    },
   ),
 ];

--- a/lib/ui/view/attachment/attachment_view.dart
+++ b/lib/ui/view/attachment/attachment_view.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:material_symbols_icons/material_symbols_icons.dart';
-import 'package:prontu_ai/routing/routes.dart';
-import 'package:prontu_ai/ui/core/ui/dialogs/app_snack_bar.dart';
-import 'package:prontu_ai/ui/core/ui/dialogs/botton_sheet_message.dart.dart';
 
+import '/routing/routes.dart';
+import '/ui/core/ui/dialogs/app_snack_bar.dart';
+import '/ui/core/ui/dialogs/botton_sheet_message.dart.dart';
 import '/domain/models/attachment_model.dart';
 import '/ui/core/theme/dimens.dart';
 import '/ui/core/ui/dismissibles/dismissible_card.dart';

--- a/lib/ui/view/attachment/form_attachment/form_attachment_view.dart
+++ b/lib/ui/view/attachment/form_attachment/form_attachment_view.dart
@@ -1,20 +1,25 @@
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:material_symbols_icons/symbols.dart';
-import 'package:prontu_ai/domain/enums/enums_declarations.dart';
-import 'package:prontu_ai/ui/core/theme/dimens.dart';
-import 'package:prontu_ai/ui/core/ui/form_fields/basic_form_field.dart';
-import 'package:prontu_ai/utils/validates/generic_validations.dart';
 
+import '/ui/core/ui/buttons/big_button.dart';
+import '/ui/core/ui/form_fields/enum_form_field.dart';
+import '/domain/enums/enums_declarations.dart';
+import '/ui/core/theme/dimens.dart';
+import '/ui/core/ui/form_fields/basic_form_field.dart';
+import '/utils/validates/generic_validations.dart';
 import '/domain/models/attachment_model.dart';
 import '/ui/view/attachment/form_attachment/form_attachment_view_model.dart';
 
 class FormAttachmentView extends StatefulWidget {
   final AttachmentModel? attachment;
+  final String sessionId;
   final FormAttachmentViewModel viewModel;
 
   const FormAttachmentView({
     super.key,
     this.attachment,
+    required this.sessionId,
     required this.viewModel,
   });
 
@@ -43,6 +48,7 @@ class _FormAttachmentViewState extends State<FormAttachmentView> {
     super.initState();
   }
 
+  @override
   void dispose() {
     super.dispose();
     viewModel.insert.removeListener(_isSaved);
@@ -79,12 +85,38 @@ class _FormAttachmentViewState extends State<FormAttachmentView> {
                 validator: GenericValidations.name,
                 prefixIconData: Symbols.docs_rounded,
               ),
-              BasicFormField(
-                labelText: 'Arquivo',
-                hintText: 'Selecione o arquivo do exame.',
-                controller: _pathController,
-                validator: GenericValidations.notEmpty,
-                prefixIconData: Symbols.document_search_rounded,
+              InkWell(
+                onTap: _selectFile,
+                child: AbsorbPointer(
+                  child: BasicFormField(
+                    labelText: 'Arquivo',
+                    hintText: 'Selecione o arquivo do exame.',
+                    controller: _pathController,
+                    validator: GenericValidations.notEmpty,
+                    prefixIconData: Symbols.document_search_rounded,
+                  ),
+                ),
+              ),
+              EnumFormField<AttachmentType>(
+                labelBuilder: (value) => value.label,
+                initialValue: _type,
+                values: AttachmentType.values,
+                onChanged: _selectType,
+                validator: GenericValidations.attachmentType,
+              ),
+              ListenableBuilder(
+                listenable: Listenable.merge([
+                  viewModel.insert,
+                  viewModel.update,
+                ]),
+                builder: (context, _) => BigButton(
+                  iconData: _isEditing ? Symbols.edit : Symbols.save,
+                  isRunning:
+                      viewModel.insert.isRunning || viewModel.update.isRunning,
+                  onPressed: _saveForm,
+                  label: _isEditing ? 'Editar' : 'Salvar',
+                  color: Colors.green,
+                ),
               ),
             ],
           ),
@@ -93,7 +125,76 @@ class _FormAttachmentViewState extends State<FormAttachmentView> {
     );
   }
 
-  void _isSaved() {}
+  void _isSaved() {
+    if (viewModel.insert.isRunning || viewModel.update.isRunning) return;
 
-  void _initializeForm() {}
+    final result = _isEditing
+        ? viewModel.update.result
+        : viewModel.insert.result;
+
+    if (result == null || result.isFailure) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text(
+            'Ocorreu um erro ao salvar o anexo.\n'
+            'Favor, tente mais tarde.',
+          ),
+        ),
+      );
+      return;
+    }
+
+    Navigator.pop(context);
+  }
+
+  void _initializeForm() {
+    final attachment = widget.attachment;
+
+    if (attachment != null) {
+      _namecontroller.text = attachment.name;
+      _pathController.text = attachment.path;
+      _type = attachment.type;
+
+      _isEditing = true;
+
+      setState(() {});
+    }
+  }
+
+  void _selectType(AttachmentType? type) => _type = type;
+
+  void _saveForm() {
+    if (viewModel.insert.isRunning || viewModel.update.isRunning) return;
+
+    if (_formKey.currentState == null || !_formKey.currentState!.validate()) {
+      return;
+    }
+
+    FocusScope.of(context).unfocus();
+
+    final attachment = AttachmentModel(
+      id: widget.attachment?.id,
+      sessionId: widget.sessionId,
+      name: _namecontroller.text.trim(),
+      path: _pathController.text.trim(),
+      type: _type!,
+    );
+
+    _isEditing
+        ? viewModel.update.execute(attachment)
+        : viewModel.insert.execute(attachment);
+  }
+
+  Future<void> _selectFile() async {
+    final result = await FilePicker.platform.pickFiles(
+      dialogTitle: 'Selecione o exame',
+      initialDirectory: '/storage/emulated/0/Download',
+      type: FileType.custom,
+      allowedExtensions: ['pdf', 'doc', 'png', 'jpg'],
+    );
+
+    if (result != null) {
+      _pathController.text = result.files.first.path!;
+    }
+  }
 }

--- a/lib/ui/view/episode/form_episode/form_episode_view.dart
+++ b/lib/ui/view/episode/form_episode/form_episode_view.dart
@@ -6,11 +6,13 @@ import '/ui/view/episode/form_episode/form_episode_view_model.dart';
 
 class FormEpisodeView extends StatefulWidget {
   final EpisodeModel? episode;
+  final String userId;
   final FormEpisodeViewModel viewModel;
 
   const FormEpisodeView({
     super.key,
     this.episode,
+    required this.userId,
     required this.viewModel,
   });
 

--- a/lib/ui/view/home/form_user/form_user_view.dart
+++ b/lib/ui/view/home/form_user/form_user_view.dart
@@ -127,9 +127,9 @@ class _FormUserViewState extends State<FormUserView> {
 
     if (result == null || result.isFailure) {
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
+        const SnackBar(
           content: Text(
-            'Ocorreu um erro ao salvar o usuário: ${result!.error}.\n'
+            'Ocorreu um erro ao salvar o usuário.\n'
             'Favor, tente mais tarde.',
           ),
         ),

--- a/lib/ui/view/session/form_session/form_session_view.dart
+++ b/lib/ui/view/session/form_session/form_session_view.dart
@@ -4,12 +4,14 @@ import '/domain/models/session_model.dart';
 import '/ui/view/session/form_session/form_session_view_model.dart';
 
 class FormSessionView extends StatefulWidget {
-  final SessionModel session;
+  final SessionModel? session;
+  final String episodeId;
   final FormSessionViewModel viewModel;
 
   const FormSessionView({
     super.key,
-    required this.session,
+    this.session,
+    required this.episodeId,
     required this.viewModel,
   });
 

--- a/lib/utils/validates/generic_validations.dart
+++ b/lib/utils/validates/generic_validations.dart
@@ -59,4 +59,12 @@ class GenericValidations {
 
     return null;
   }
+
+  static String? attachmentType(AttachmentType? value) {
+    if (value == null) {
+      return 'Tipo de arquivo é obrigatório.';
+    }
+
+    return null;
+  }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -57,6 +57,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "7caf6a750a0c04effbb52a676dce9a4a592e10ad35c34d6d2d0e4811160d5670"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.4+2"
   crypto:
     dependency: transitive
     description:
@@ -97,6 +105,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  file_picker:
+    dependency: "direct main"
+    description:
+      name: file_picker
+      sha256: ef9908739bdd9c476353d6adff72e88fd00c625f5b959ae23f7567bd5137db0a
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.2.0"
   fixnum:
     dependency: transitive
     description:
@@ -118,6 +134,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      sha256: f948e346c12f8d5480d2825e03de228d0eb8c3a737e4cdaa122267b89c022b5e
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.28"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -493,6 +517,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: "66814138c3562338d05613a6e368ed8cfb237ad6d64a9e9334be3f309acfca03"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.14.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
   go_router: ^15.2.0
   google_fonts: ^6.2.1
   material_symbols_icons: ^4.2815.1
+  file_picker: ^10.2.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### Add file picker support and extend attachment/session route parameters

This commit enhances attachment handling by introducing a `name` field to the `AttachmentModel`, integrates the `file_picker` package for file selection, and refactors routing to pass additional identifiers (`userId`, `episodeId`, `sessionId`). Validation and UI elements have been updated accordingly to improve the form interaction and maintain consistency across views.

### Modified Files

* **lib/domain/models/attachment\_model.dart**

  * Introduced a new `name` property and required it in the constructor.
  * Made `createdAt` optional with a default of `DateTime.now()`.
  * Updated `copyWith`, `toMap`, and `fromMap` methods to include `name`.

* **lib/routing/router.dart**

  * Refactored `formEpisode`, `formSession`, and `formAttachment` routes to read `state.extra` as a `Map<String, dynamic>`.
  * Extracted and passed `userId`, `episodeId`, and `sessionId` to their respective views.
  * Simplified builder signatures and removed old `state.extra as Model` casts.

* **lib/routing/routes\_base/attachment\_routes.dart**

  * Mirrored the router changes: now unpacks `sessionId` and optional `attachment` from `state.extra`.

* **lib/ui/view/attachment/attachment\_view\.dart**

  * Corrected import paths to use root-relative (`/routing` and `/ui/core`) instead of package prefixes.

* **lib/ui/view/attachment/form\_attachment/form\_attachment\_view\.dart**

  * Added `file_picker` import and declared a required `sessionId` parameter on `FormAttachmentView`.
  * Replaced plain button with `BigButton` and wrapped the file path field in an `InkWell` to trigger `_selectFile()`.
  * Inserted an `EnumFormField` for selecting `AttachmentType`.
  * Implemented `_initializeForm()`, `_isSaved()`, and `_saveForm()` methods to handle edit/save logic and error reporting.
  * Integrated `FilePicker` to allow users to choose files with specific extensions.

* **lib/ui/view/episode/form\_episode/form\_episode\_view\.dart**

  * Added a required `userId` field to the `FormEpisodeView` constructor.

* **lib/ui/view/home/form\_user/form\_user\_view\.dart**

  * Made the `SnackBar` constant and removed the inline error interpolation for consistency.

* **lib/ui/view/session/form\_session/form\_session\_view\.dart**

  * Changed `session` to be nullable and introduced a required `episodeId` parameter.

* **lib/utils/validates/generic\_validations.dart**

  * Added a new `attachmentType` validator to ensure a file type is selected.

* **pubspec.yaml**

  * Added `file_picker: ^10.2.0` to dependencies for file selection functionality.

### Conclusion

### All changes complete – attachment forms now support naming and file selection, and routing carries the correct identifiers.