### PR TITLE
2025/06/19 routing-02 - by rudsonalves

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,32 @@ A new Flutter project.
 
 # ChangeLog
 
+## 2025/06/19 routing-02 - by rudsonalves
+
+### Add new tables to initialization, extend attachments schema, and increase vertical spacing
+
+This commit enhances database setup by including sessions, episodes, attachments, and AI summaries tables in the batch creation, updates the attachments table to store a `name` field, and refines the mobile UI spacing by increasing the vertical gap. These changes ensure all core models persist locally and improve layout consistency.
+
+### Modified Files
+
+* **lib/data/services/database/database\_service.dart**
+
+  * Added execution of `SqlTables.sessions`, `SqlTables.episodes`, `SqlTables.attachments`, and `SqlTables.aiSummaries` in the batch initialization to create these tables on startup.
+
+* **lib/data/services/database/tables/sql\_tables.dart**
+
+  * Introduced a required `name TEXT NOT NULL` column in the `attachments` table definition to store a human-readable identifier alongside `path` and `type`.
+
+* **lib/ui/core/theme/dimens.dart**
+
+  * Increased `spacingVertical` from `6.0` to `24.0` in the mobile dimensions class to provide more generous vertical padding across UI elements.
+
+
+### Conclusion
+
+All core tables are now initialized, the attachments schema is extended with names, and vertical spacing is improved—local persistence and UI layout are fully updated.
+
+
 ## 2025/06/19 database-01 - by rudsonalves
 
 ### Add new tables to initialization, extend attachments schema, and increase vertical spacing

--- a/lib/routing/router.dart
+++ b/lib/routing/router.dart
@@ -113,7 +113,8 @@ GoRouter router() => GoRouter(
         // Sessions pages
         ShellRoute(
           builder: (context, state, child) {
-            final episode = state.extra as EpisodeModel;
+            final map = state.extra as Map<String, dynamic>;
+            final episode = map['episode'] as EpisodeModel;
 
             final sessionRepository = SessionRepository(
               episodeId: episode.id!,
@@ -129,23 +130,32 @@ GoRouter router() => GoRouter(
             GoRoute(
               path: Routes.session.path,
               name: Routes.session.name,
-              builder: (context, state) => SessionView(
-                episode: state.extra as EpisodeModel,
-                viewModel: SessionViewModel(
-                  RepositoryScope.of<ISessionRepository>(context),
-                ),
-              ),
+              builder: (context, state) {
+                final map = state.extra as Map<String, dynamic>;
+                final user = map['user'] as UserModel;
+                final episode = map['episode'] as EpisodeModel;
+
+                return SessionView(
+                  user: user,
+                  episode: episode,
+                  viewModel: SessionViewModel(
+                    RepositoryScope.of<ISessionRepository>(context),
+                  ),
+                );
+              },
             ),
             GoRoute(
               path: Routes.formSession.path,
               name: Routes.formSession.name,
               builder: (context, state) {
                 final map = state.extra as Map<String, dynamic>;
-                final episodeId = map['episode_id'] as String;
+                final user = map['user'] as UserModel;
+                final episode = map['episode'] as EpisodeModel;
                 final session = map['session'] as SessionModel?;
 
                 return FormSessionView(
-                  episodeId: episodeId,
+                  user: user,
+                  episode: episode,
                   session: session,
                   viewModel: FormSessionViewModel(
                     RepositoryScope.of<ISessionRepository>(context),
@@ -156,7 +166,8 @@ GoRouter router() => GoRouter(
             // Attachments pages
             ShellRoute(
               builder: (context, state, child) {
-                final session = state.extra as SessionModel;
+                final map = state.extra as Map<String, dynamic>;
+                final session = map['session'] as SessionModel;
 
                 final attachmentRepository = AttachmentRepository(
                   sessionId: session.id!,
@@ -172,23 +183,36 @@ GoRouter router() => GoRouter(
                 GoRoute(
                   path: Routes.attachment.path,
                   name: Routes.attachment.name,
-                  builder: (context, state) => AttachmentView(
-                    session: state.extra as SessionModel,
-                    viewModel: AttachmentViewModel(
-                      RepositoryScope.of<IAttachmentRepository>(context),
-                    ),
-                  ),
+                  builder: (context, state) {
+                    final map = state.extra as Map<String, dynamic>;
+                    final user = map['user'] as UserModel;
+                    final episode = map['episode'] as EpisodeModel;
+                    final session = map['session'] as SessionModel;
+
+                    return AttachmentView(
+                      user: user,
+                      episode: episode,
+                      session: session,
+                      viewModel: AttachmentViewModel(
+                        RepositoryScope.of<IAttachmentRepository>(context),
+                      ),
+                    );
+                  },
                 ),
                 GoRoute(
                   path: Routes.formAttachment.path,
                   name: Routes.formAttachment.name,
                   builder: (context, state) {
                     final map = state.extra as Map<String, dynamic>;
+                    final user = map['user'] as UserModel;
+                    final episode = map['episode'] as EpisodeModel;
+                    final session = map['session'] as SessionModel;
                     final attachment = map['attachment'] as AttachmentModel?;
-                    final sessionId = map['session_id'] as String;
 
                     return FormAttachmentView(
-                      sessionId: sessionId,
+                      user: user,
+                      episode: episode,
+                      session: session,
                       attachment: attachment,
                       viewModel: FormAttachmentViewModel(
                         RepositoryScope.of<IAttachmentRepository>(context),

--- a/lib/ui/view/attachment/attachment_view.dart
+++ b/lib/ui/view/attachment/attachment_view.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:material_symbols_icons/material_symbols_icons.dart';
+import 'package:prontu_ai/domain/models/episode_model.dart';
+import 'package:prontu_ai/domain/models/user_model.dart';
 
 import '/routing/routes.dart';
 import '/ui/core/ui/dialogs/app_snack_bar.dart';
@@ -13,11 +15,15 @@ import '/domain/models/session_model.dart';
 import '/ui/view/attachment/attachment_view_model.dart';
 
 class AttachmentView extends StatefulWidget {
+  final UserModel user;
+  final EpisodeModel episode;
   final SessionModel session;
   final AttachmentViewModel viewModel;
 
   const AttachmentView({
     super.key,
+    required this.user,
+    required this.episode,
     required this.session,
     required this.viewModel,
   });

--- a/lib/ui/view/attachment/form_attachment/form_attachment_view.dart
+++ b/lib/ui/view/attachment/form_attachment/form_attachment_view.dart
@@ -1,6 +1,9 @@
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:material_symbols_icons/symbols.dart';
+import 'package:prontu_ai/domain/models/episode_model.dart';
+import 'package:prontu_ai/domain/models/session_model.dart';
+import 'package:prontu_ai/domain/models/user_model.dart';
 
 import '/ui/core/ui/buttons/big_button.dart';
 import '/ui/core/ui/form_fields/enum_form_field.dart';
@@ -12,14 +15,18 @@ import '/domain/models/attachment_model.dart';
 import '/ui/view/attachment/form_attachment/form_attachment_view_model.dart';
 
 class FormAttachmentView extends StatefulWidget {
+  final UserModel user;
+  final EpisodeModel episode;
+  final SessionModel session;
   final AttachmentModel? attachment;
-  final String sessionId;
   final FormAttachmentViewModel viewModel;
 
   const FormAttachmentView({
     super.key,
     this.attachment,
-    required this.sessionId,
+    required this.user,
+    required this.episode,
+    required this.session,
     required this.viewModel,
   });
 
@@ -174,7 +181,7 @@ class _FormAttachmentViewState extends State<FormAttachmentView> {
 
     final attachment = AttachmentModel(
       id: widget.attachment?.id,
-      sessionId: widget.sessionId,
+      sessionId: widget.session.id!,
       name: _namecontroller.text.trim(),
       path: _pathController.text.trim(),
       type: _type!,

--- a/lib/ui/view/session/form_session/form_session_view.dart
+++ b/lib/ui/view/session/form_session/form_session_view.dart
@@ -1,17 +1,21 @@
 import 'package:flutter/widgets.dart';
+import 'package:prontu_ai/domain/models/episode_model.dart';
+import 'package:prontu_ai/domain/models/user_model.dart';
 
 import '/domain/models/session_model.dart';
 import '/ui/view/session/form_session/form_session_view_model.dart';
 
 class FormSessionView extends StatefulWidget {
+  final UserModel user;
+  final EpisodeModel episode;
   final SessionModel? session;
-  final String episodeId;
   final FormSessionViewModel viewModel;
 
   const FormSessionView({
     super.key,
     this.session,
-    required this.episodeId,
+    required this.user,
+    required this.episode,
     required this.viewModel,
   });
 

--- a/lib/ui/view/session/session_view.dart
+++ b/lib/ui/view/session/session_view.dart
@@ -1,15 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:material_symbols_icons/symbols.dart';
+import 'package:prontu_ai/domain/models/user_model.dart';
 
 import '/domain/models/episode_model.dart';
 import '/ui/view/session/session_view_model.dart';
 
 class SessionView extends StatefulWidget {
+  final UserModel user;
   final EpisodeModel episode;
   final SessionViewModel viewModel;
 
   const SessionView({
     super.key,
+    required this.user,
     required this.episode,
     required this.viewModel,
   });


### PR DESCRIPTION
### Add new tables to initialization, extend attachments schema, and increase vertical spacing

This commit enhances database setup by including sessions, episodes, attachments, and AI summaries tables in the batch creation, updates the attachments table to store a `name` field, and refines the mobile UI spacing by increasing the vertical gap. These changes ensure all core models persist locally and improve layout consistency.

### Modified Files

* **lib/data/services/database/database\_service.dart**

  * Added execution of `SqlTables.sessions`, `SqlTables.episodes`, `SqlTables.attachments`, and `SqlTables.aiSummaries` in the batch initialization to create these tables on startup.

* **lib/data/services/database/tables/sql\_tables.dart**

  * Introduced a required `name TEXT NOT NULL` column in the `attachments` table definition to store a human-readable identifier alongside `path` and `type`.

* **lib/ui/core/theme/dimens.dart**

  * Increased `spacingVertical` from `6.0` to `24.0` in the mobile dimensions class to provide more generous vertical padding across UI elements.

### Conclusion

All core tables are now initialized, the attachments schema is extended with names, and vertical spacing is improved—local persistence and UI layout are fully updated.