### PR TITLE
2025/06/20 splash-suh - by Suelen

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,52 @@ A new Flutter project.
 
 # ChangeLog
 
+## 2025/06/20 splash-suh - by Suelen
+
+### Add animated splash screen and update initial routing
+
+Implemented a new animated splash screen to enhance the app’s startup experience. Updated routing to launch the splash view first, registered the splash view and its ViewModel, and included new assets for icons. Adjusted asset declarations in `pubspec.yaml` to ensure proper bundling.
+
+### Modified Files
+
+* **lib/routing/router.dart**
+
+  * Switched `initialLocation` from `Routes.home.path` to `Routes.splash.path`.
+  * Refactored imports for internal packages to use absolute paths (`/data/...`, `/domain/...`).
+  * Added imports for `SplashLogoView` and `SplashViewModel`.
+  * Inserted a `GoRoute` entry for the splash screen before the home route.
+
+* **lib/routing/routes.dart**
+
+  * Introduced `static const splash = Route('splash', '/splash');` to define the splash route.
+
+* **pubspec.yaml**
+
+  * Expanded the `assets` section to include the new `assets/icons/` directory alongside existing images.
+
+### New Files
+
+* **lib/ui/view/splash/splash\_view\.dart**
+  Implements `SplashLogoView`, a stateful widget that:
+
+  * Controls a 3-second `AnimationController` with a `Tween` scaling from 0.30 to 1.6.
+  * Uses `ScaleTransition` to animate the logo asset based on current theme.
+  * Waits 500 ms after the animation and then navigates to the home route.
+
+* **lib/ui/view/splash/splash\_view\_model.dart**
+  Defines `SplashViewModel`, wrapping `AppThemeMode` to expose an `isDark` flag for asset selection.
+
+### Assets and Test Data
+
+* **assets/icons/**
+
+  * New directory registered for application icons.
+
+### Conclusion
+
+All changes complete—splash screen flow is now integrated and the app starts with the animated view successfully.
+
+
 ## 2025/06/20 ia_service-04 - by rudsonalves
 
 ### Refactor AI summary workflow, add MedicalRecord DTO, upsert support, and UI polish

--- a/lib/routing/router.dart
+++ b/lib/routing/router.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-import 'package:prontu_ai/data/repositories/ai_summary/i_ai_summary_repository.dart';
-import 'package:prontu_ai/domain/user_cases/episode_ai_summary_user_case.dart';
 import 'package:provider/provider.dart';
 
+import '/data/repositories/ai_summary/i_ai_summary_repository.dart';
+import '/domain/user_cases/episode_ai_summary_user_case.dart';
+import '/ui/view/splash/splash_view.dart';
+import '/ui/view/splash/splash_view_model.dart';
 import '/data/repositories/attachment/i_attachment_repository.dart';
 import '/data/repositories/episode/i_episode_repository.dart';
 import '/data/repositories/session/i_session_repository.dart';
@@ -32,8 +34,17 @@ import '/routing/routes.dart';
 import '/ui/view/home/home_view.dart';
 
 GoRouter router() => GoRouter(
-  initialLocation: Routes.home.path,
+  initialLocation: Routes.splash.path,
   routes: [
+    GoRoute(
+      path: Routes.splash.path,
+      name: Routes.splash.name,
+      builder: (context, state) => SplashLogoView(
+        viewModel: SplashViewModel(
+          themeMode: context.read<AppThemeMode>(),
+        ),
+      ),
+    ),
     GoRoute(
       path: Routes.home.path,
       name: Routes.home.name,

--- a/lib/routing/routes.dart
+++ b/lib/routing/routes.dart
@@ -6,6 +6,8 @@ class Route {
 }
 
 abstract final class Routes {
+  static const splash = Route('splash', '/splash');
+
   static const home = Route('home', '/');
   static const formUser = Route('form_user', '/form_user');
 

--- a/lib/ui/view/splash/splash_view.dart
+++ b/lib/ui/view/splash/splash_view.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '/ui/view/splash/splash_view_model.dart';
+import '/routing/routes.dart';
+import '/ui/core/theme/dimens.dart';
+
+class SplashLogoView extends StatefulWidget {
+  final SplashViewModel viewModel;
+
+  const SplashLogoView({super.key, required this.viewModel});
+
+  @override
+  State<SplashLogoView> createState() => _SplashLogoViewState();
+}
+
+class _SplashLogoViewState extends State<SplashLogoView>
+    with SingleTickerProviderStateMixin {
+  late final SplashViewModel viewModel;
+  late final AnimationController _controller;
+  late final Animation<double> _scaleAnimation;
+
+  @override
+  void initState() {
+    super.initState();
+    viewModel = widget.viewModel;
+
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(seconds: 3),
+    );
+
+    _scaleAnimation = Tween<double>(begin: 0.30, end: 1.6).animate(
+      CurvedAnimation(
+        parent: _controller,
+        curve: Curves.easeInOutBack,
+      ),
+    );
+
+    _startAnimationSequence();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final dimens = Dimens.of(context);
+
+    const double logoSize = 200;
+
+    return Scaffold(
+      backgroundColor: colorScheme.surface,
+      body: Center(
+        child: Padding(
+          padding: EdgeInsets.all(dimens.paddingScreenAll * 3),
+          child: ScaleTransition(
+            scale: _scaleAnimation,
+            child: Image.asset(
+              viewModel.isDark
+                  ? 'assets/images/splash1.png'
+                  : 'assets/images/splash2.png',
+              width: logoSize,
+              height: logoSize,
+              fit: BoxFit.contain,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _startAnimationSequence() async {
+    await _controller.forward();
+    await Future.delayed(const Duration(milliseconds: 500));
+    if (mounted) context.go(Routes.home.path);
+  }
+}

--- a/lib/ui/view/splash/splash_view_model.dart
+++ b/lib/ui/view/splash/splash_view_model.dart
@@ -1,0 +1,11 @@
+import '/app_theme_mode.dart';
+
+class SplashViewModel {
+  final AppThemeMode _themeMode;
+
+  SplashViewModel({
+    required AppThemeMode themeMode,
+  }) : _themeMode = themeMode;
+
+  bool get isDark => _themeMode.isDark;
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,3 +39,4 @@ flutter:
   assets:
     - .env
     - assets/images/
+    - assets/icons/


### PR DESCRIPTION
### Add animated splash screen and update initial routing

Implemented a new animated splash screen to enhance the app’s startup experience. Updated routing to launch the splash view first, registered the splash view and its ViewModel, and included new assets for icons. Adjusted asset declarations in `pubspec.yaml` to ensure proper bundling.

### Modified Files

* **lib/routing/router.dart**

  * Switched `initialLocation` from `Routes.home.path` to `Routes.splash.path`.
  * Refactored imports for internal packages to use absolute paths (`/data/...`, `/domain/...`).
  * Added imports for `SplashLogoView` and `SplashViewModel`.
  * Inserted a `GoRoute` entry for the splash screen before the home route.

* **lib/routing/routes.dart**

  * Introduced `static const splash = Route('splash', '/splash');` to define the splash route.

* **pubspec.yaml**

  * Expanded the `assets` section to include the new `assets/icons/` directory alongside existing images.

### New Files

* **lib/ui/view/splash/splash\_view\.dart** Implements `SplashLogoView`, a stateful widget that:

  * Controls a 3-second `AnimationController` with a `Tween` scaling from 0.30 to 1.6.
  * Uses `ScaleTransition` to animate the logo asset based on current theme.
  * Waits 500 ms after the animation and then navigates to the home route.

* **lib/ui/view/splash/splash\_view\_model.dart** Defines `SplashViewModel`, wrapping `AppThemeMode` to expose an `isDark` flag for asset selection.

### Assets and Test Data

* **assets/icons/**

  * New directory registered for application icons.

### Conclusion

All changes complete—splash screen flow is now integrated and the app starts with the animated view successfully.